### PR TITLE
fix: clarify AI helper auto shares selected table paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Smart VLookUper 智能数据映射工具
 
 全新的AI助手窗口支持历史对话、多轮指令与实时代码/执行日志预览，可将复杂任务拆分为多步链式操作，逐步验证每一步的结果。
 
+AI助手会自动将已选择的Excel文件绝对路径传递给模型，用户只需描述处理目标即可，系统会在后台引用正确路径以避免“Required Files Not Found”等访问错误。
+
 必备库： pyqt6 pandas openpyxl pywin32 thefuzz openai
 
 支持Windows/macOS/Linux，推荐Windows获得最佳性能。


### PR DESCRIPTION
## Summary
- update README to explain that the AI helper automatically provides selected Excel paths to the model
- adjust AI helper UI placeholder and logging so users know they need not retype the paths manually
- refine AI prompt instructions to note the runtime already injects the absolute paths

## Testing
- python -m compileall SMART-VLOOKUPER.py

------
https://chatgpt.com/codex/tasks/task_e_68ca314e82408323bb9d419458662750